### PR TITLE
DUX-3507: support curl logs endpoint

### DIFF
--- a/server/src/explore.rs
+++ b/server/src/explore.rs
@@ -33,7 +33,7 @@ pub fn make_router() -> axum::Router<AppState> {
 const BUFFER_SIZE: u64 = 64 * 1024;
 
 #[tracing::instrument(level = "info", skip(state))]
-async fn get_explore(
+pub(crate) async fn get_explore(
     state: extract::State<AppState>,
     extract::Path((bucket, filename)): extract::Path<(String, String)>,
 ) -> Result<Response<Body>, ApiError> {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -44,6 +44,7 @@ pub fn make_app(state: AppState) -> axum::Router {
             get(|| async { "This is https://github.com/MercuryTechnologies/locally-euclidean" }),
         )
         .nest("/v0", api::make_router())
+        .nest("/v1/logs", api::make_buck2_logs_router())
         .nest("/explore", explore::make_router())
         .layer(
             // Process middleware requests top to bottom then responses are
@@ -58,7 +59,7 @@ pub fn make_app(state: AppState) -> axum::Router {
                 // Include trace context as header into the response
                 .layer(OtelInResponseLayer)
                 .layer(security_headers::cors())
-                .layer(axum::middleware::from_fn(security_headers::headers)),
+                .layer(axum::middleware::map_response(security_headers::headers)),
         )
         .with_state(state)
         // Processed *outside* span

--- a/server/src/security_headers.rs
+++ b/server/src/security_headers.rs
@@ -4,11 +4,7 @@
 //! uploading HTML.
 //!
 //! FIXME(jadel): find more fun headers to set
-use axum::{
-    http::{HeaderValue, header},
-    middleware::Next,
-    response::Response,
-};
+use axum::http::{HeaderValue, header};
 use tower_http::cors::CorsLayer;
 
 const DEFAULT_HEADERS: [(header::HeaderName, HeaderValue); 4] = [
@@ -27,8 +23,9 @@ const DEFAULT_HEADERS: [(header::HeaderName, HeaderValue); 4] = [
     ),
 ];
 
-pub(crate) async fn headers(request: axum::extract::Request, next: Next) -> Response {
-    let mut response = next.run(request).await;
+pub(crate) async fn headers<Body>(
+    mut response: axum::response::Response<Body>,
+) -> axum::response::Response<Body> {
     let headers = response.headers_mut();
     for (name, value) in DEFAULT_HEADERS {
         headers.entry(name).or_insert(value);

--- a/storage/src/file_backend.rs
+++ b/storage/src/file_backend.rs
@@ -347,7 +347,6 @@ impl Bucket for FileBucket {
     // tokio punts it to spawn_blocking anyway.
 
     #[tracing::instrument(level = "debug")]
-    #[must_use]
     async fn file(&self, file_name: &str) -> Result<Self::FileHandle, FileOpenError> {
         let path = FileHandle::make_acceptable_filepath(Utf8Path::new(file_name))
             .map_err(|_| FileOpenError::InvalidName)?;
@@ -375,7 +374,6 @@ impl Bucket for FileBucket {
     }
 
     #[tracing::instrument(level = "debug")]
-    #[must_use]
     async fn create_file(&self, file_name: &str) -> Result<Self::FileHandle, FileCreateError> {
         let path = FileHandle::make_acceptable_filepath(Utf8Path::new(file_name))
             .map_err(|_| FileCreateError::InvalidName)?;
@@ -439,7 +437,6 @@ impl StorageBackend for FileBackend {
     type Bucket<'a> = Arc<FileBucket>;
 
     #[tracing::instrument(level = "debug", skip(self))]
-    #[must_use]
     async fn bucket(&self, name: &str) -> Result<Self::Bucket<'_>, FileOpenError> {
         // These would constitute path traversal bugs when combined with
         // PathBuf::join
@@ -465,7 +462,6 @@ impl StorageBackend for FileBackend {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    #[must_use]
     async fn list_buckets(&self) -> Result<Vec<String>, BoxError> {
         let mut iter = tokio::fs::read_dir(&self.root_dir).await?;
         let mut names = Vec::new();


### PR DESCRIPTION
This is required to translate between the "vendor neutral" /v1/logs/get API that is normal HTTP, invented in https://github.com/facebook/buck2/pull/770 and the underlying manifold-like storage.

We have to support this HTTP API since buck2's alternative to that is manifold get bucket/file which we don't have at runtime in buck2.