### PR TITLE
DUX-3529: add a way to create buckets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2244,7 @@ dependencies = [
  "config",
  "http-body-util",
  "httpdate",
+ "humantime",
  "init-tracing-opentelemetry",
  "opentelemetry",
  "opentelemetry_sdk",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,6 +35,7 @@ httpdate = "1.0.3"
 clap = { version = "4.5.39", features = ["derive"] }
 sqlx.workspace = true
 chrono.workspace = true
+humantime = "2.2.0"
 
 [dev-dependencies]
 axum-test.workspace = true


### PR DESCRIPTION
Since we switched to postgres, we do not want to have to use raw SQL to
be able to do this maintenance. Thus, we need a one-off-task like thing.