### PR TITLE
docker: also tag with the sha, correctly

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -27,6 +27,7 @@ jobs:
           # accept-flake-config is not normally ok. it's still not great here,
           # but putting code in our flake.nix is equivalent to this in this
           # case anyway.
-          registry_path=$(echo "ghcr.io/${{ github.repository_owner }}/locally-euclidean:latest" | tr 'A-Z' 'a-z')
-          EXTRA_TAGS="${{ github.sha }}" nix run -L --accept-flake-config .#docker-push "$registry_path"
+          registry_path=$(echo "ghcr.io/${{ github.repository_owner }}/locally-euclidean" | tr 'A-Z' 'a-z')
+          nix run -L --accept-flake-config .#docker-push "$registry_path:latest"
+          nix run -L --accept-flake-config .#docker-push "$registry_path:${{ github.sha }}"
 

--- a/nix/packages/docker-push.nix
+++ b/nix/packages/docker-push.nix
@@ -28,9 +28,6 @@ writeShellApplication {
       docker-archive:${docker-image}
       "docker://$registry_path"
     )
-    if [[ -v $EXTRA_TAGS ]]; then
-      args+=(--additional-tag "$EXTRA_TAGS")
-    fi
     skopeo "''${args[@]}"
   '';
   meta = {


### PR DESCRIPTION
Turns out the old approach was simply wrong, as the docker-archive
transport here was referring to the destination (and also my bash was
wrong): https://github.com/containers/skopeo/issues/513