### PR TITLE
DUX-3574: add setting for bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,10 @@ You can use the sqlx tools to do migration development:
 **Currently** (this would be bad practice if the app were larger), migrations are run on application startup and no effort is made to prevent blowing up prod with this.
 
 Don't write migrations that break back-compat for the prior version of the app.
+
+## Deploying our prod instance
+
+If you work at Mercury, you currently have to manually deploy the prod instance.
+
+Trigger this GitHub action (in our private repo) to deploy:
+<https://github.com/MercuryTechnologies/infra-apps/actions/workflows/deploy-locally-euclidean.yml>

--- a/nix/packages/docker-image.nix
+++ b/nix/packages/docker-image.nix
@@ -25,6 +25,13 @@ let
         # "OTEL_EXPORTER_OTLP_ENDPOINT=http://somehost:4317"
         # "OTEL_EXPORTER_OTLP_PROTOCOL=grpc"
         # "OTEL_TRACES_EXPORTER=otlp"
+
+        # I am uncertain whether this is necessary, since SURELY the port
+        # redirects are done *from within* the container so listening on
+        # [::1]:9000 should be fine, but I am committing this while trying to
+        # fix a health check that makes no sense why it is failing and which is
+        # not getting any requests through. Shrug!
+        "LOC_EUC_BIND_ADDRESS=[::]:9000"
       ];
       Entrypoint = [
         "${lib.getExe tini}"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,3 +1,5 @@
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
+
 use axum::BoxError;
 
 #[derive(Debug, thiserror::Error)]
@@ -22,6 +24,15 @@ pub struct AppConfig {
     #[serde(default = "AppConfig::default_allowed_content_types")]
     pub allowed_content_types: Vec<String>,
 
+    /// Bind address for the server.
+    ///
+    /// NOTE: the default only allows connections from localhost! This may or
+    /// may not be a problem depending on setup.
+    ///
+    /// This is [::1]:9000.
+    #[serde(default = "AppConfig::default_bind_address")]
+    pub bind_address: SocketAddr,
+
     /// Database connection string for a Postgres database [according to sqlx](https://docs.rs/sqlx/0.8.6/sqlx/postgres/struct.PgConnectOptions.html).
     pub db_connection_string: String,
 }
@@ -39,11 +50,16 @@ impl AppConfig {
         ]
     }
 
+    fn default_bind_address() -> SocketAddr {
+        SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 9000, 0, 0))
+    }
+
     /// Creates a testing AppConfig. Database sold separately.
     pub fn build_for_test() -> Result<AppConfig, BoxError> {
         Ok(AppConfig {
             max_upload_size_mb: 5,
             allowed_content_types: Self::default_allowed_content_types(),
+            bind_address: Self::default_bind_address(),
             // Garbage value, not actually used
             db_connection_string: "".to_owned(),
         })


### PR DESCRIPTION
Turns out that the AWS LB possibly requires that you set the bind address to
accept connections from not just localhost, which is um. weird given that the containers stuff exposes the port so shouldn't care.