### PR TITLE
[DUX-3531] [DUX-3572] implement a cleanup task for old files

### DIFF
--- a/.sqlx/query-1f072473a29bdceb7fcb8b400c21d2644a683bed8c64dbda2807b82e18698af1.json
+++ b/.sqlx/query-1f072473a29bdceb7fcb8b400c21d2644a683bed8c64dbda2807b82e18698af1.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            with deletion_batch as (\n                select id from files\n                where delete_after is not null and delete_after < now()\n                order by delete_after asc\n                for update\n                limit 1000\n            ) delete from files as fs\n                using deletion_batch as dl\n                where dl.id = fs.id\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "1f072473a29bdceb7fcb8b400c21d2644a683bed8c64dbda2807b82e18698af1"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +683,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +770,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1189,6 +1214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1359,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1552,6 +1613,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking"
@@ -2242,10 +2309,12 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "futures",
  "http-body-util",
  "httpdate",
  "humantime",
  "init-tracing-opentelemetry",
+ "miette",
  "opentelemetry",
  "opentelemetry_sdk",
  "serde",
@@ -2612,6 +2681,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,6 +2743,26 @@ dependencies = [
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -3099,6 +3209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3228,18 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ config = { version = "0.15.11", features = ["toml"], default-features = false }
 tokio-util = { version = "0.7.15", features = ["tracing"] }
 chrono = "0.4.41"
 futures-core = "0.3.31"
+futures = "0.3.31"
 assert-impl = "0.1.3"
 
 # Unix

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,7 +35,10 @@ httpdate = "1.0.3"
 clap = { version = "4.5.39", features = ["derive"] }
 sqlx.workspace = true
 chrono.workspace = true
+futures.workspace = true
 humantime = "2.2.0"
+# miette is a fancy cat! this feature gives us colour error output
+miette = { version = "7.6.0", features = ["fancy"] }
 
 [dev-dependencies]
 axum-test.workspace = true

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -2,7 +2,7 @@ use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 
 use axum::BoxError;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
 pub enum ConfigBuildError {
     #[error("Failed to collect config items: {0}")]
     FailedToCollect(::config::ConfigError),

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 mod errors;
 pub mod explore;
 mod security_headers;
+pub mod tasks;
 pub mod tracing_setup;
 
 use std::sync::{Arc, LazyLock};

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -27,7 +27,7 @@ pub struct AppStateInner {
     pub store: PostgresBackend,
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, miette::Diagnostic, Debug)]
 pub enum AppStartupError {
     #[error("Failed to connect to database: {0}")]
     ConnectToDB(sqlx::Error),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,9 @@
-use axum::BoxError;
 use clap::Parser as _;
+use futures::future::FutureExt;
+use miette::Context;
+use miette::IntoDiagnostic;
+use miette::Result;
+use miette::miette;
 use server::AppStateInner;
 use server::config::AppConfig;
 use server::make_app;
@@ -50,12 +54,17 @@ struct Args {
     subcommand: Subcommand,
 }
 
-async fn run_maintenance(config: AppConfig, maintenance: Maintenance) -> Result<(), BoxError> {
+async fn run_maintenance(config: AppConfig, maintenance: Maintenance) -> Result<()> {
     let state = AppStateInner::new(config).await?;
 
     match maintenance.task {
         MaintenanceTask::CreateBucket(CreateBucketArgs { name, default_ttl }) => {
-            let bucket = state.store.create_bucket(&name, default_ttl).await?;
+            let bucket = state
+                .store
+                .create_bucket(&name, default_ttl)
+                .await
+                .into_diagnostic()
+                .wrap_err("Creating the bucket failed")?;
             tracing::info!("Created: {bucket:?}");
         }
     }
@@ -63,11 +72,13 @@ async fn run_maintenance(config: AppConfig, maintenance: Maintenance) -> Result<
 }
 
 #[tokio::main]
-async fn main() -> Result<(), BoxError> {
+async fn main() -> Result<()> {
     // FIXME(jadel): this feels so complex, idk if the
     // init_tracing_opentelemetry crate is the right thing for this. OTOH it
     // does the right thing.
-    let _guard = tracing_setup::init_subscribers()?;
+    let _guard = tracing_setup::init_subscribers()
+        .map_err(|e| miette!(e))
+        .wrap_err("Tracing setup failed")?;
 
     let args = Args::parse();
     let config = AppConfig::build()?;
@@ -89,14 +100,31 @@ async fn main() -> Result<(), BoxError> {
             });
 
             info!("Starting scheduled maintenance tasks");
-            tasks::start_maintenance_tasks(state.clone(), terminate.clone()).await;
+            let tasks_fut = tasks::start_maintenance_tasks(state.clone(), terminate.clone()).await;
 
             info!("Listening on http://{}", state.config.bind_address);
-            let listener = tokio::net::TcpListener::bind(state.config.bind_address).await?;
+            let listener = tokio::net::TcpListener::bind(state.config.bind_address)
+                .await
+                .into_diagnostic()
+                .wrap_err("Failed to create listener")?;
 
-            axum::serve(listener, app)
-                .with_graceful_shutdown(terminate.cancelled_owned())
-                .await?;
+            let listener_fut = axum::serve(listener, app)
+                .with_graceful_shutdown(terminate.clone().cancelled_owned());
+
+            tokio::try_join!(
+                async {
+                    let res = listener_fut.await;
+                    // Failing to start the listener means we should stop
+                    // altogether.
+                    if res.is_err() {
+                        terminate.cancel();
+                    }
+                    res.into_diagnostic().wrap_err("Failed to listen")
+                },
+                tasks_fut.into_future().map(|res| res
+                    .into_diagnostic()
+                    .wrap_err("Failed to join background tasks"))
+            )?;
         }
         Subcommand::Maintenance(maintenance) => run_maintenance(config, maintenance).await?,
     };

--- a/server/src/tasks.rs
+++ b/server/src/tasks.rs
@@ -1,0 +1,35 @@
+//! Automated idempotent maintenance tasks.
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::AppState;
+
+/// Runs all the async maintenance jobs
+pub async fn start_maintenance_tasks(
+    app_state: AppState,
+    terminate: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn({
+        let app_state = app_state.clone();
+        let terminate = terminate.clone();
+        let mut interval = tokio::time::interval(Duration::from_secs(120));
+        async move {
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    _ = terminate.cancelled() => {}
+                }
+                if terminate.is_cancelled() {
+                    break;
+                }
+
+                let result = app_state.store.delete_old_files_batch().await;
+                if let Err(err) = result {
+                    tracing::error!(err, "Error while deleting old files");
+                }
+            }
+        }
+    })
+}


### PR DESCRIPTION
These don't have to do any additional cleanup besides deleting the
records in the DB as a trigger will delete the linked blob objects. Will
have to be revisited if/when we bother tiering stuff out to S3
(DUX-3532).